### PR TITLE
DOCSP-19987 - Fix Windows "Permission Denied" Error

### DIFF
--- a/docs-examples/examples/v1.4/cdc-tutorial/docker-compose.yml
+++ b/docs-examples/examples/v1.4/cdc-tutorial/docker-compose.yml
@@ -74,6 +74,9 @@ services:
   mongo1-setup:
     image: "cdc-tutorial-mongod:1.0"
     container_name: mongo1-setup
+    build:
+      context: .
+      dockerfile: Dockerfile-Mongo
     depends_on:
       - mongo1
     networks:

--- a/docs-examples/examples/v1.4/quickstart/docker-compose.yml
+++ b/docs-examples/examples/v1.4/quickstart/docker-compose.yml
@@ -74,6 +74,9 @@ services:
   mongo1-setup:
     image: "quickstart-mongod:1.0"
     container_name: mongo1-setup
+    build:
+      context: .
+      dockerfile: Dockerfile-Mongo
     depends_on:
       - mongo1
     networks:

--- a/docs-examples/examples/v1.5/cdc-tutorial/docker-compose.yml
+++ b/docs-examples/examples/v1.5/cdc-tutorial/docker-compose.yml
@@ -74,6 +74,9 @@ services:
   mongo1-setup:
     image: "cdc-tutorial-mongod:1.0"
     container_name: mongo1-setup
+    build:
+      context: .
+      dockerfile: Dockerfile-Mongo
     depends_on:
       - mongo1
     networks:

--- a/docs-examples/examples/v1.5/quickstart/docker-compose.yml
+++ b/docs-examples/examples/v1.5/quickstart/docker-compose.yml
@@ -74,6 +74,9 @@ services:
   mongo1-setup:
     image: "quickstart-mongod:1.0"
     container_name: mongo1-setup
+    build:
+      context: .
+      dockerfile: Dockerfile-Mongo
     depends_on:
       - mongo1
     networks:

--- a/docs-examples/examples/v1.6/cdc-tutorial/docker-compose.yml
+++ b/docs-examples/examples/v1.6/cdc-tutorial/docker-compose.yml
@@ -74,6 +74,9 @@ services:
   mongo1-setup:
     image: "cdc-tutorial-mongod:1.0"
     container_name: mongo1-setup
+    build:
+      context: .
+      dockerfile: Dockerfile-Mongo
     depends_on:
       - mongo1
     networks:

--- a/docs-examples/examples/v1.6/quickstart/docker-compose.yml
+++ b/docs-examples/examples/v1.6/quickstart/docker-compose.yml
@@ -74,6 +74,9 @@ services:
   mongo1-setup:
     image: "quickstart-mongod:1.0"
     container_name: mongo1-setup
+    build:
+      context: .
+      dockerfile: Dockerfile-Mongo
     depends_on:
       - mongo1
     networks:

--- a/docs-examples/source/cdc-tutorial/docker-compose.yml
+++ b/docs-examples/source/cdc-tutorial/docker-compose.yml
@@ -74,6 +74,9 @@ services:
   mongo1-setup:
     image: "cdc-tutorial-mongod:1.0"
     container_name: mongo1-setup
+    build:
+      context: .
+      dockerfile: Dockerfile-Mongo
     depends_on:
       - mongo1
     networks:

--- a/docs-examples/source/quickstart/docker-compose.yml
+++ b/docs-examples/source/quickstart/docker-compose.yml
@@ -74,6 +74,9 @@ services:
   mongo1-setup:
     image: "quickstart-mongod:1.0"
     container_name: mongo1-setup
+    build:
+      context: .
+      dockerfile: Dockerfile-Mongo
     depends_on:
       - mongo1
     networks:


### PR DESCRIPTION
There seems to be a difference in behavior between Docker Compose on Windows and Mac:

On Mac, if a container is dependent on another container and the containers use the same image, you do not need to specify a build argument for the container which is built second as the image will be built when it is created.

On Windows, if a build argument is not specified for a container, then docker immediately checks docker-hub to see if the container exists. 

To fix this error, build arguments were specified for the `mongo1-setup` container in all tutorials.

I'm not sure this is a known issue, so it may be worth making an issue in the docker-compose [repository](https://github.com/docker/compose) to document this.
