### PR TITLE
(DOCSP-20991) Add v1.7 Connector Examples

### DIFF
--- a/docs-examples/examples/v1.7/cdc-tutorial/Dockerfile-Mongo
+++ b/docs-examples/examples/v1.7/cdc-tutorial/Dockerfile-Mongo
@@ -1,0 +1,2 @@
+FROM mongo:latest
+COPY config-replica.js config-data.js /

--- a/docs-examples/examples/v1.7/cdc-tutorial/Dockerfile-MongoConnect
+++ b/docs-examples/examples/v1.7/cdc-tutorial/Dockerfile-MongoConnect
@@ -1,0 +1,5 @@
+FROM confluentinc/cp-kafka-connect:latest
+
+RUN confluent-hub install --no-prompt mongodb/kafka-connect-mongodb:1.7.0
+
+ENV CONNECT_PLUGIN_PATH="/usr/share/java,/usr/share/confluent-hub-components"

--- a/docs-examples/examples/v1.7/cdc-tutorial/Dockerfile-shell
+++ b/docs-examples/examples/v1.7/cdc-tutorial/Dockerfile-shell
@@ -1,0 +1,22 @@
+FROM ubuntu:latest
+RUN apt-get -y update
+RUN apt-get -y upgrade
+RUN apt-get install -y curl; apt-get install -y kafkacat
+RUN apt-get install -y jq; apt-get install -y bsdmainutils 
+# install mongosh
+RUN curl https://downloads.mongodb.com/compass/mongodb-mongosh_1.0.0_amd64.deb -o mongosh.deb && \
+    dpkg --install mongosh.deb
+COPY tutorial-scripts/initialize-container.sh /
+RUN chmod +x initialize-container.sh
+
+# Modify command prompt
+RUN echo 'PS1="\[\e[32m\][\e[mMongoDB Kafka Connector Tutorial\e[32m]\e[m : "' >> ~/.bashrc
+
+# Add welcome text
+COPY greeting.sh tutorial-scripts/status.sh /
+RUN chmod +x status.sh
+RUN cat greeting.sh >> ~/.bashrc
+
+# Cleanup
+RUN rm mongosh.deb
+RUN rm greeting.sh

--- a/docs-examples/examples/v1.7/cdc-tutorial/README.md
+++ b/docs-examples/examples/v1.7/cdc-tutorial/README.md
@@ -1,0 +1,6 @@
+# Replicate Data with a Change Data Capture Handler Tutorial
+
+This directory contains files you need to build the MongoDB Kafka Connector
+"Replicate Data with a Change Data Capture Handler" Tutorial for v1.7 of the connector.
+
+[You can view the tutorial here](https://docs.mongodb.com/kafka-connector/v1.7/tutorials/replicate-with-cdc/).

--- a/docs-examples/examples/v1.7/cdc-tutorial/config-data.js
+++ b/docs-examples/examples/v1.7/cdc-tutorial/config-data.js
@@ -1,0 +1,3 @@
+db = db.getSiblingDB("quickstart");
+db.createCollection("source");
+db.createCollection("sink");

--- a/docs-examples/examples/v1.7/cdc-tutorial/config-replica.js
+++ b/docs-examples/examples/v1.7/cdc-tutorial/config-replica.js
@@ -1,0 +1,6 @@
+rsconf = {
+  _id: "rs0",
+  members: [{ _id: 0, host: "mongo1:27017", priority: 1.0 }],
+};
+rs.initiate(rsconf);
+rs.status();

--- a/docs-examples/examples/v1.7/cdc-tutorial/docker-compose.yml
+++ b/docs-examples/examples/v1.7/cdc-tutorial/docker-compose.yml
@@ -1,0 +1,106 @@
+version: "3.7"
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:latest
+    hostname: zookeeper
+    container_name: zookeeper
+    networks:
+      - localnet
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+
+  broker:
+    image: confluentinc/cp-kafka:latest
+    hostname: broker
+    container_name: broker
+    depends_on:
+      - zookeeper
+    networks:
+      - localnet
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
+      KAFKA_LISTENERS: LISTENER_1://broker:29092,LISTENER_2://broker:9092
+      KAFKA_ADVERTISED_LISTENERS: LISTENER_1://broker:29092,LISTENER_2://localhost:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: LISTENER_1:PLAINTEXT,LISTENER_2:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: LISTENER_1
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      CONFLUENT_SUPPORT_CUSTOMER_ID: "anonymous"
+      KAFKA_DELETE_TOPIC_ENABLE: "true"
+
+  connect:
+    image: cdc-tutorial-connect-1.7.0:1.0
+    build:
+      context: .
+      dockerfile: Dockerfile-MongoConnect
+    hostname: connect
+    container_name: connect
+    depends_on:
+      - zookeeper
+      - broker
+    networks:
+      - localnet
+    environment:
+      CONNECT_BOOTSTRAP_SERVERS: "broker:29092"
+      CONNECT_REST_ADVERTISED_HOST_NAME: connect
+      CONNECT_REST_PORT: 8083
+      CONNECT_GROUP_ID: connect-cluster-group
+      CONNECT_CONFIG_STORAGE_TOPIC: docker-connect-configs
+      CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR: 1
+      CONNECT_OFFSET_FLUSH_INTERVAL_MS: 10000
+      CONNECT_OFFSET_STORAGE_TOPIC: docker-connect-offsets
+      CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR: 1
+      CONNECT_STATUS_STORAGE_TOPIC: docker-connect-status
+      CONNECT_STATUS_STORAGE_REPLICATION_FACTOR: 1
+      CONNECT_ZOOKEEPER_CONNECT: "zookeeper:2181"
+      CONNECT_PLUGIN_PATH: "/usr/share/java,/usr/share/confluent-hub-components"
+      CONNECT_AUTO_CREATE_TOPICS_ENABLE: "true"
+      CONNECT_KEY_CONVERTER: "org.apache.kafka.connect.json.JsonConverter"
+      CONNECT_VALUE_CONVERTER: "org.apache.kafka.connect.json.JsonConverter"
+
+  mongo1:
+    image: "cdc-tutorial-mongod:1.0"
+    container_name: mongo1
+    build:
+      context: .
+      dockerfile: Dockerfile-Mongo
+    command: --replSet rs0
+    networks:
+      - localnet
+    restart: always
+
+  mongo1-setup:
+    image: "cdc-tutorial-mongod:1.0"
+    container_name: mongo1-setup
+    depends_on:
+      - mongo1
+    networks:
+      - localnet
+    entrypoint:
+      [
+        "bash",
+        "-c",
+        "sleep 10 && mongo --host mongodb://mongo1:27017 config-replica.js && sleep 10 && mongo --host mongodb://mongo1:27017 config-data.js",
+      ]
+    restart: "no"
+
+  shell:
+    image: "cdc-tutorial-shell:1.0"
+    container_name: shell
+    build:
+      context: .
+      dockerfile: Dockerfile-shell
+    depends_on:
+      - zookeeper
+      - broker
+      - connect
+      - mongo1
+    networks:
+      - localnet
+    command: bash -c "./initialize-container.sh ; tail -f /dev/null"
+
+networks:
+  localnet:
+    attachable: true

--- a/docs-examples/examples/v1.7/cdc-tutorial/greeting.sh
+++ b/docs-examples/examples/v1.7/cdc-tutorial/greeting.sh
@@ -1,0 +1,1 @@
+echo -e "Version 1.0\n\nTools installed:\n\nKafkacat - Apache Kafka command line producer and consumer tool for Kafka\nMongoSH - MongoDB command line shell\n\n"

--- a/docs-examples/examples/v1.7/cdc-tutorial/initialize-container.sh
+++ b/docs-examples/examples/v1.7/cdc-tutorial/initialize-container.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# exponential back off as kafka connect starts
+curl --connect-timeout 5 \
+     --max-time 10 \
+     --retry 6 \
+     --retry-delay 0 \
+     --retry-max-time 80 \
+     --retry-connrefused \
+     -X POST -H "Content-Type: application/json" --data @source-connector.json http://connect:8083/connectors -w "\n"
+curl -X POST -H "Content-Type: application/json" --data @sink-connector.json http://connect:8083/connectors -w "\n"
+# print all connectors added to kafka connect
+curl -X GET http://connect:8083/connectors

--- a/docs-examples/examples/v1.7/cdc-tutorial/sink-connector-cdc.json
+++ b/docs-examples/examples/v1.7/cdc-tutorial/sink-connector-cdc.json
@@ -1,0 +1,11 @@
+{
+  "name": "mongo-sink",
+  "config": {
+    "connector.class": "com.mongodb.kafka.connect.MongoSinkConnector",
+    "connection.uri": "mongodb://mongo1",
+    "change.data.capture.handler": "com.mongodb.kafka.connect.sink.cdc.mongodb.ChangeStreamHandler",
+    "database": "quickstart",
+    "collection": "sink",
+    "topics": "quickstart.source"
+  }
+}

--- a/docs-examples/examples/v1.7/cdc-tutorial/sink-connector.json
+++ b/docs-examples/examples/v1.7/cdc-tutorial/sink-connector.json
@@ -1,0 +1,14 @@
+{
+  "name": "mongo-sink",
+  "config": {
+    "connector.class": "com.mongodb.kafka.connect.MongoSinkConnector",
+    "connection.uri": "mongodb://mongo1",
+    "database": "quickstart",
+    "collection": "sink",
+    "topics": "quickstart.source",
+    "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+    "value.converter.schemas.enable": "false",
+    "key.converter": "org.apache.kafka.connect.json.JsonConverter",
+    "key.converter.schemas.enable": "false"
+  }
+}

--- a/docs-examples/examples/v1.7/cdc-tutorial/source-connector.json
+++ b/docs-examples/examples/v1.7/cdc-tutorial/source-connector.json
@@ -1,0 +1,9 @@
+{
+  "name": "mongo-source",
+  "config": {
+    "connector.class": "com.mongodb.kafka.connect.MongoSourceConnector",
+    "connection.uri": "mongodb://mongo1",
+    "database": "quickstart",
+    "collection": "source"
+  }
+}

--- a/docs-examples/examples/v1.7/cdc-tutorial/tutorial-scripts/commands.sh
+++ b/docs-examples/examples/v1.7/cdc-tutorial/tutorial-scripts/commands.sh
@@ -1,0 +1,19 @@
+curl -X POST -H "Content-Type: application/json" --data '
+{ "name":  "mongo-source-tutorial3-eventroundtrip",
+  "config": {
+    "connector.class":"com.mongodb.kafka.connect.MongoSourceConnector",
+    "connection.uri":"mongodb://mongo1:27017,mongo2:27017,mongo3:27017",
+    "database":"Tutorial3","collection":"Source"}
+}' http://connect:8083/connectors -w "\n" | jq .
+
+curl -X POST -H "Content-Type: application/json" --data '
+{ "name": "mongo-sink-tutorial3-eventroundtrip", 
+  "config": {
+  "connector.class":"com.mongodb.kafka.connect.MongoSinkConnector",
+  "tasks.max":"1",
+  "topics":"Tutorial3.Source",
+  "change.data.capture.handler":"com.mongodb.kafka.connect.sink.cdc.mongodb.ChangeStreamHandler",
+  "connection.uri":"mongodb://mongo1:27017,mongo2:27017,mongo3:27017",
+  "database":"Tutorial3",
+  "collection":"Destination"}
+}' http://connect:8083/connectors -w "\n" | jq .

--- a/docs-examples/examples/v1.7/cdc-tutorial/tutorial-scripts/initialize-container.sh
+++ b/docs-examples/examples/v1.7/cdc-tutorial/tutorial-scripts/initialize-container.sh
@@ -1,0 +1,17 @@
+curl --connect-timeout 5 \
+     --max-time 10 \
+     --retry 6 \
+     --retry-delay 0 \
+     --retry-max-time 80 \
+     --retry-connrefused \
+     -X POST -H "Content-Type: application/json" --data '
+{ "name":  "mongo-source-CDCTutorial-eventroundtrip",
+  "config": {
+    "connector.class":"com.mongodb.kafka.connect.MongoSourceConnector",
+    "connection.uri":"mongodb://mongo1:27017,mongo2:27017,mongo3:27017",
+    "database":"CDCTutorial","collection":"Source"}
+}' http://connect:8083/connectors -w "\n"
+# As this topic does not exist when this script runs, the following command
+# triggers a leader election for the topic. The subsequent run of this command
+# by the reader watches the topic.
+kafkacat -b broker:29092 -C -t CDCTutorial.Source

--- a/docs-examples/examples/v1.7/cdc-tutorial/tutorial-scripts/shell1.sh
+++ b/docs-examples/examples/v1.7/cdc-tutorial/tutorial-scripts/shell1.sh
@@ -1,0 +1,1 @@
+kafkacat -b broker:29092 -C -t Tutorial3.Source

--- a/docs-examples/examples/v1.7/cdc-tutorial/tutorial-scripts/status.sh
+++ b/docs-examples/examples/v1.7/cdc-tutorial/tutorial-scripts/status.sh
@@ -1,0 +1,14 @@
+printf '\nKafka topics:\n'
+
+kafkacat -b broker:29092 -L | grep topic
+
+printf '\nThe status of the connectors:\n'
+
+curl -s "http://connect:8083/connectors?expand=info&expand=status" | jq '. | to_entries[] | [ .value.info.type, .key, .value.status.connector.state,.value.status.tasks[].state,.value.info.config."connector.class"]|join(":|:")' | \
+           column -s : -t| sed 's/\"//g'| sort
+
+printf '\nCurrently configured connectors\n'
+curl --silent -X GET http://connect:8083/connectors | jq
+
+printf '\n\nVersion of MongoDB Connector for Apache Kafka installed:\n'
+curl --silent http://connect:8083/connector-plugins | jq -c '.[] | select( .class == "com.mongodb.kafka.connect.MongoSourceConnector" or .class == "com.mongodb.kafka.connect.MongoSinkConnector" )'

--- a/docs-examples/examples/v1.7/quickstart/Dockerfile-Mongo
+++ b/docs-examples/examples/v1.7/quickstart/Dockerfile-Mongo
@@ -1,0 +1,2 @@
+FROM mongo:latest
+COPY config-replica.js config-data.js /

--- a/docs-examples/examples/v1.7/quickstart/Dockerfile-MongoConnect
+++ b/docs-examples/examples/v1.7/quickstart/Dockerfile-MongoConnect
@@ -1,0 +1,5 @@
+FROM confluentinc/cp-kafka-connect:latest
+
+RUN confluent-hub install --no-prompt mongodb/kafka-connect-mongodb:1.7.0
+
+ENV CONNECT_PLUGIN_PATH="/usr/share/java,/usr/share/confluent-hub-components"

--- a/docs-examples/examples/v1.7/quickstart/Dockerfile-shell
+++ b/docs-examples/examples/v1.7/quickstart/Dockerfile-shell
@@ -1,0 +1,20 @@
+FROM ubuntu:latest
+RUN apt-get -y update
+RUN apt-get -y upgrade
+RUN apt-get install -y curl; apt-get install -y kafkacat
+# install mongosh
+RUN curl https://downloads.mongodb.com/compass/mongodb-mongosh_1.0.0_amd64.deb -o mongosh.deb && \
+    dpkg --install mongosh.deb
+COPY source-connector.json sink-connector.json sink-connector-cdc.json initialize-container.sh /
+RUN chmod +x initialize-container.sh
+
+# Modify command prompt
+RUN echo 'PS1="\[\e[32m\][\e[mMongoDB Kafka Connector Quick Start\e[32m]\e[m : "' >> ~/.bashrc
+
+# Add welcome text
+COPY greeting.sh /
+RUN cat greeting.sh >> ~/.bashrc
+
+# Cleanup
+RUN rm mongosh.deb
+RUN rm greeting.sh

--- a/docs-examples/examples/v1.7/quickstart/README.md
+++ b/docs-examples/examples/v1.7/quickstart/README.md
@@ -1,0 +1,6 @@
+# Quick Start
+
+This directory contains files you need to build the MongoDB Kafka Connector Quick Start
+for v1.7 of the connector.
+
+[You can view the quick start here](https://docs.mongodb.com/kafka-connector/v1.7/quick-start/).

--- a/docs-examples/examples/v1.7/quickstart/config-data.js
+++ b/docs-examples/examples/v1.7/quickstart/config-data.js
@@ -1,0 +1,3 @@
+db = db.getSiblingDB("quickstart");
+db.createCollection("source");
+db.createCollection("sink");

--- a/docs-examples/examples/v1.7/quickstart/config-replica.js
+++ b/docs-examples/examples/v1.7/quickstart/config-replica.js
@@ -1,0 +1,6 @@
+rsconf = {
+  _id: "rs0",
+  members: [{ _id: 0, host: "mongo1:27017", priority: 1.0 }],
+};
+rs.initiate(rsconf);
+rs.status();

--- a/docs-examples/examples/v1.7/quickstart/docker-compose.yml
+++ b/docs-examples/examples/v1.7/quickstart/docker-compose.yml
@@ -1,0 +1,106 @@
+version: "3.7"
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:latest
+    hostname: zookeeper
+    container_name: zookeeper
+    networks:
+      - localnet
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+
+  broker:
+    image: confluentinc/cp-kafka:latest
+    hostname: broker
+    container_name: broker
+    depends_on:
+      - zookeeper
+    networks:
+      - localnet
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
+      KAFKA_LISTENERS: LISTENER_1://broker:29092,LISTENER_2://broker:9092
+      KAFKA_ADVERTISED_LISTENERS: LISTENER_1://broker:29092,LISTENER_2://localhost:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: LISTENER_1:PLAINTEXT,LISTENER_2:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: LISTENER_1
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      CONFLUENT_SUPPORT_CUSTOMER_ID: "anonymous"
+      KAFKA_DELETE_TOPIC_ENABLE: "true"
+
+  connect:
+    image: quickstart-connect-1.7.0:1.0
+    build:
+      context: .
+      dockerfile: Dockerfile-MongoConnect
+    hostname: connect
+    container_name: connect
+    depends_on:
+      - zookeeper
+      - broker
+    networks:
+      - localnet
+    environment:
+      CONNECT_BOOTSTRAP_SERVERS: "broker:29092"
+      CONNECT_REST_ADVERTISED_HOST_NAME: connect
+      CONNECT_REST_PORT: 8083
+      CONNECT_GROUP_ID: connect-cluster-group
+      CONNECT_CONFIG_STORAGE_TOPIC: docker-connect-configs
+      CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR: 1
+      CONNECT_OFFSET_FLUSH_INTERVAL_MS: 10000
+      CONNECT_OFFSET_STORAGE_TOPIC: docker-connect-offsets
+      CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR: 1
+      CONNECT_STATUS_STORAGE_TOPIC: docker-connect-status
+      CONNECT_STATUS_STORAGE_REPLICATION_FACTOR: 1
+      CONNECT_ZOOKEEPER_CONNECT: "zookeeper:2181"
+      CONNECT_PLUGIN_PATH: "/usr/share/java,/usr/share/confluent-hub-components"
+      CONNECT_AUTO_CREATE_TOPICS_ENABLE: "true"
+      CONNECT_KEY_CONVERTER: "org.apache.kafka.connect.json.JsonConverter"
+      CONNECT_VALUE_CONVERTER: "org.apache.kafka.connect.json.JsonConverter"
+
+  mongo1:
+    image: "quickstart-mongod:1.0"
+    container_name: mongo1
+    build:
+      context: .
+      dockerfile: Dockerfile-Mongo
+    command: --replSet rs0
+    networks:
+      - localnet
+    restart: always
+
+  mongo1-setup:
+    image: "quickstart-mongod:1.0"
+    container_name: mongo1-setup
+    depends_on:
+      - mongo1
+    networks:
+      - localnet
+    entrypoint:
+      [
+        "bash",
+        "-c",
+        "sleep 10 && mongo --host mongodb://mongo1:27017 config-replica.js && sleep 10 && mongo --host mongodb://mongo1:27017 config-data.js",
+      ]
+    restart: "no"
+
+  shell:
+    image: "quickstart-shell:1.0"
+    container_name: shell
+    build:
+      context: .
+      dockerfile: Dockerfile-shell
+    depends_on:
+      - zookeeper
+      - broker
+      - connect
+      - mongo1
+    networks:
+      - localnet
+    command: "tail -f /dev/null"
+
+networks:
+  localnet:
+    attachable: true

--- a/docs-examples/examples/v1.7/quickstart/greeting.sh
+++ b/docs-examples/examples/v1.7/quickstart/greeting.sh
@@ -1,0 +1,1 @@
+echo -e "Version 1.0\n\nTools installed:\n\nKafkacat - Apache Kafka command line producer and consumer tool for Kafka\nMongoSH - MongoDB command line shell\n\n"

--- a/docs-examples/examples/v1.7/quickstart/initialize-container.sh
+++ b/docs-examples/examples/v1.7/quickstart/initialize-container.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# exponential back off as kafka connect starts
+curl --connect-timeout 5 \
+     --max-time 10 \
+     --retry 6 \
+     --retry-delay 0 \
+     --retry-max-time 80 \
+     --retry-connrefused \
+     -X POST -H "Content-Type: application/json" --data @source-connector.json http://connect:8083/connectors -w "\n"
+curl -X POST -H "Content-Type: application/json" --data @sink-connector.json http://connect:8083/connectors -w "\n"
+# print all connectors added to kafka connect
+curl -X GET http://connect:8083/connectors

--- a/docs-examples/examples/v1.7/quickstart/sink-connector-cdc.json
+++ b/docs-examples/examples/v1.7/quickstart/sink-connector-cdc.json
@@ -1,0 +1,11 @@
+{
+  "name": "mongo-sink",
+  "config": {
+    "connector.class": "com.mongodb.kafka.connect.MongoSinkConnector",
+    "connection.uri": "mongodb://mongo1",
+    "change.data.capture.handler": "com.mongodb.kafka.connect.sink.cdc.mongodb.ChangeStreamHandler",
+    "database": "quickstart",
+    "collection": "sink",
+    "topics": "quickstart.source"
+  }
+}

--- a/docs-examples/examples/v1.7/quickstart/sink-connector.json
+++ b/docs-examples/examples/v1.7/quickstart/sink-connector.json
@@ -1,0 +1,14 @@
+{
+  "name": "mongo-sink",
+  "config": {
+    "connector.class": "com.mongodb.kafka.connect.MongoSinkConnector",
+    "connection.uri": "mongodb://mongo1",
+    "database": "quickstart",
+    "collection": "sink",
+    "topics": "quickstart.source",
+    "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+    "value.converter.schemas.enable": "false",
+    "key.converter": "org.apache.kafka.connect.json.JsonConverter",
+    "key.converter.schemas.enable": "false"
+  }
+}

--- a/docs-examples/examples/v1.7/quickstart/source-connector.json
+++ b/docs-examples/examples/v1.7/quickstart/source-connector.json
@@ -1,0 +1,9 @@
+{
+  "name": "mongo-source",
+  "config": {
+    "connector.class": "com.mongodb.kafka.connect.MongoSourceConnector",
+    "connection.uri": "mongodb://mongo1",
+    "database": "quickstart",
+    "collection": "source"
+  }
+}

--- a/docs-examples/scripts/build.py
+++ b/docs-examples/scripts/build.py
@@ -21,6 +21,7 @@ CONFLUENT_VERSION = "confluent_hub_version"
 # The following dictionary captures connector version information from this website:
 # https://www.confluent.io/hub/mongodb/kafka-connect-mongodb
 REPLACE_MAP = {
+    "v1.7": "1.7.0",
     "v1.6": "1.6.1",
     "v1.5": "1.5.1",
     "v1.4": "1.4.0",


### PR DESCRIPTION
Add Docker examples for the v1.7 connector.

I tested the `quickstart` and `cdc-tutorial` with the new v1.7 directory and they seem to work.

## JIRA

https://jira.mongodb.org/browse/DOCSP-20991

### Note:

Started the playbook for updating the connector version at Chris' request [here](https://docs.google.com/document/d/1CY06pyn_zsezDMkiTwtUP6Mm0pEaS5PrQDxemSwPuNo/edit)
