### PR TITLE
Quick Start Feedback

### DIFF
--- a/docs-examples/examples/v1.4/quickstart/Dockerfile-Mongo
+++ b/docs-examples/examples/v1.4/quickstart/Dockerfile-Mongo
@@ -1,2 +1,2 @@
-FROM mongo:latest
+FROM mongo:6.0.1
 COPY config-replica.js config-data.js /

--- a/docs-examples/examples/v1.4/quickstart/Dockerfile-MongoConnect
+++ b/docs-examples/examples/v1.4/quickstart/Dockerfile-MongoConnect
@@ -1,4 +1,4 @@
-FROM confluentinc/cp-kafka-connect:latest
+FROM confluentinc/cp-kafka-connect:7.2.1
 
 RUN confluent-hub install --no-prompt mongodb/kafka-connect-mongodb:1.4.0
 

--- a/docs-examples/examples/v1.4/quickstart/Dockerfile-shell
+++ b/docs-examples/examples/v1.4/quickstart/Dockerfile-shell
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:18.04
 RUN apt-get -y update
 RUN apt-get -y upgrade
 RUN apt-get install -y curl; apt-get install -y kafkacat

--- a/docs-examples/examples/v1.4/quickstart/docker-compose.yml
+++ b/docs-examples/examples/v1.4/quickstart/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:latest
+    image: confluentinc/cp-zookeeper:7.2.1
     hostname: zookeeper
     container_name: zookeeper
     networks:
@@ -11,7 +11,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:latest
+    image: confluentinc/cp-kafka:7.2.1
     hostname: broker
     container_name: broker
     depends_on:
@@ -85,7 +85,7 @@ services:
       [
         "bash",
         "-c",
-        "sleep 10 && mongo --host mongodb://mongo1:27017 config-replica.js && sleep 10 && mongo --host mongodb://mongo1:27017 config-data.js",
+        "sleep 10 && mongosh --host mongo1:27017 config-replica.js && sleep 10 && mongosh --host mongo1:27017 config-data.js",
       ]
     restart: "no"
 

--- a/docs-examples/examples/v1.5/quickstart/Dockerfile-Mongo
+++ b/docs-examples/examples/v1.5/quickstart/Dockerfile-Mongo
@@ -1,2 +1,2 @@
-FROM mongo:latest
+FROM mongo:6.0.1
 COPY config-replica.js config-data.js /

--- a/docs-examples/examples/v1.5/quickstart/Dockerfile-MongoConnect
+++ b/docs-examples/examples/v1.5/quickstart/Dockerfile-MongoConnect
@@ -1,4 +1,4 @@
-FROM confluentinc/cp-kafka-connect:latest
+FROM confluentinc/cp-kafka-connect:7.2.1
 
 RUN confluent-hub install --no-prompt mongodb/kafka-connect-mongodb:1.5.1
 

--- a/docs-examples/examples/v1.5/quickstart/Dockerfile-shell
+++ b/docs-examples/examples/v1.5/quickstart/Dockerfile-shell
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:18.04
 RUN apt-get -y update
 RUN apt-get -y upgrade
 RUN apt-get install -y curl; apt-get install -y kafkacat

--- a/docs-examples/examples/v1.5/quickstart/docker-compose.yml
+++ b/docs-examples/examples/v1.5/quickstart/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:latest
+    image: confluentinc/cp-zookeeper:7.2.1
     hostname: zookeeper
     container_name: zookeeper
     networks:
@@ -11,7 +11,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:latest
+    image: confluentinc/cp-kafka:7.2.1
     hostname: broker
     container_name: broker
     depends_on:
@@ -85,7 +85,7 @@ services:
       [
         "bash",
         "-c",
-        "sleep 10 && mongo --host mongodb://mongo1:27017 config-replica.js && sleep 10 && mongo --host mongodb://mongo1:27017 config-data.js",
+        "sleep 10 && mongosh --host mongo1:27017 config-replica.js && sleep 10 && mongosh --host mongo1:27017 config-data.js",
       ]
     restart: "no"
 

--- a/docs-examples/examples/v1.6/quickstart/Dockerfile-Mongo
+++ b/docs-examples/examples/v1.6/quickstart/Dockerfile-Mongo
@@ -1,2 +1,2 @@
-FROM mongo:latest
+FROM mongo:6.0.1
 COPY config-replica.js config-data.js /

--- a/docs-examples/examples/v1.6/quickstart/Dockerfile-MongoConnect
+++ b/docs-examples/examples/v1.6/quickstart/Dockerfile-MongoConnect
@@ -1,4 +1,4 @@
-FROM confluentinc/cp-kafka-connect:latest
+FROM confluentinc/cp-kafka-connect:7.2.1
 
 RUN confluent-hub install --no-prompt mongodb/kafka-connect-mongodb:1.6.1
 

--- a/docs-examples/examples/v1.6/quickstart/Dockerfile-shell
+++ b/docs-examples/examples/v1.6/quickstart/Dockerfile-shell
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:18.04
 RUN apt-get -y update
 RUN apt-get -y upgrade
 RUN apt-get install -y curl; apt-get install -y kafkacat

--- a/docs-examples/examples/v1.6/quickstart/docker-compose.yml
+++ b/docs-examples/examples/v1.6/quickstart/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:latest
+    image: confluentinc/cp-zookeeper:7.2.1
     hostname: zookeeper
     container_name: zookeeper
     networks:
@@ -11,7 +11,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:latest
+    image: confluentinc/cp-kafka:7.2.1
     hostname: broker
     container_name: broker
     depends_on:
@@ -85,7 +85,7 @@ services:
       [
         "bash",
         "-c",
-        "sleep 10 && mongo --host mongodb://mongo1:27017 config-replica.js && sleep 10 && mongo --host mongodb://mongo1:27017 config-data.js",
+        "sleep 10 && mongosh --host mongo1:27017 config-replica.js && sleep 10 && mongosh --host mongo1:27017 config-data.js",
       ]
     restart: "no"
 

--- a/docs-examples/examples/v1.7/quickstart/Dockerfile-Mongo
+++ b/docs-examples/examples/v1.7/quickstart/Dockerfile-Mongo
@@ -1,2 +1,2 @@
-FROM mongo:latest
+FROM mongo:6.0.1
 COPY config-replica.js config-data.js /

--- a/docs-examples/examples/v1.7/quickstart/Dockerfile-MongoConnect
+++ b/docs-examples/examples/v1.7/quickstart/Dockerfile-MongoConnect
@@ -1,4 +1,4 @@
-FROM confluentinc/cp-kafka-connect:latest
+FROM confluentinc/cp-kafka-connect:7.2.1
 
 RUN confluent-hub install --no-prompt mongodb/kafka-connect-mongodb:1.7.0
 

--- a/docs-examples/examples/v1.7/quickstart/Dockerfile-shell
+++ b/docs-examples/examples/v1.7/quickstart/Dockerfile-shell
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:18.04
 RUN apt-get -y update
 RUN apt-get -y upgrade
 RUN apt-get install -y curl; apt-get install -y kafkacat

--- a/docs-examples/examples/v1.7/quickstart/docker-compose.yml
+++ b/docs-examples/examples/v1.7/quickstart/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:latest
+    image: confluentinc/cp-zookeeper:7.2.1
     hostname: zookeeper
     container_name: zookeeper
     networks:
@@ -11,7 +11,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:latest
+    image: confluentinc/cp-kafka:7.2.1
     hostname: broker
     container_name: broker
     depends_on:
@@ -74,6 +74,9 @@ services:
   mongo1-setup:
     image: "quickstart-mongod:1.0"
     container_name: mongo1-setup
+    build:
+      context: .
+      dockerfile: Dockerfile-Mongo
     depends_on:
       - mongo1
     networks:
@@ -82,7 +85,7 @@ services:
       [
         "bash",
         "-c",
-        "sleep 10 && mongo --host mongodb://mongo1:27017 config-replica.js && sleep 10 && mongo --host mongodb://mongo1:27017 config-data.js",
+        "sleep 10 && mongosh --host mongo1:27017 config-replica.js && sleep 10 && mongosh --host mongo1:27017 config-data.js",
       ]
     restart: "no"
 

--- a/docs-examples/source/quickstart/Dockerfile-Mongo
+++ b/docs-examples/source/quickstart/Dockerfile-Mongo
@@ -1,2 +1,2 @@
-FROM mongo:latest
+FROM mongo:6.0.1
 COPY config-replica.js config-data.js /

--- a/docs-examples/source/quickstart/Dockerfile-MongoConnect
+++ b/docs-examples/source/quickstart/Dockerfile-MongoConnect
@@ -1,4 +1,4 @@
-FROM confluentinc/cp-kafka-connect:latest
+FROM confluentinc/cp-kafka-connect:7.2.1
 
 RUN confluent-hub install --no-prompt mongodb/kafka-connect-mongodb:MONGODB_KAFKA_CONNECTOR_VERSION
 

--- a/docs-examples/source/quickstart/Dockerfile-shell
+++ b/docs-examples/source/quickstart/Dockerfile-shell
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:18.04
 RUN apt-get -y update
 RUN apt-get -y upgrade
 RUN apt-get install -y curl; apt-get install -y kafkacat

--- a/docs-examples/source/quickstart/docker-compose.yml
+++ b/docs-examples/source/quickstart/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:latest
+    image: confluentinc/cp-zookeeper:7.2.1
     hostname: zookeeper
     container_name: zookeeper
     networks:
@@ -11,7 +11,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:latest
+    image: confluentinc/cp-kafka:7.2.1
     hostname: broker
     container_name: broker
     depends_on:
@@ -85,7 +85,7 @@ services:
       [
         "bash",
         "-c",
-        "sleep 10 && mongo --host mongodb://mongo1:27017 config-replica.js && sleep 10 && mongo --host mongodb://mongo1:27017 config-data.js",
+        "sleep 10 && mongosh --host mongo1:27017 config-replica.js && sleep 10 && mongosh --host mongo1:27017 config-data.js",
       ]
     restart: "no"
 


### PR DESCRIPTION
Implement suggested fix from docs feedback : `mongo` -> `mongosh`. `mongo 6.0.1` image does not ship with `mongo` tool.

Pin versions of images in Quick Start to reduce likelihood that this sort of issue happens in the future.

This PR does not update the `cdc-tutorial` source files as this activity is not longer included in docs. H[ere is a ticket to delete the source files + built files for this activity](https://jira.mongodb.org/browse/DOCSP-25160).
