### PR TITLE
Update mongo.Dockerfile

### DIFF
--- a/docs-examples/mongodb-kafka-base/mongo.Dockerfile
+++ b/docs-examples/mongodb-kafka-base/mongo.Dockerfile
@@ -1,4 +1,4 @@
-FROM mongo:6.0.1
+FROM mongo:6.0.5
 
 COPY config-replica.js /
 COPY .bashrc /data/db/.bashrc


### PR DESCRIPTION
Changed the mongo version from 6.0.1 to 6.0.5 to overcome the package issue during the docker image build process. Below was the error observed when ran the docker-compose with 6.0.1,

pkg: error processing package mongodb-org-server (--configure):
 end of file on stdin at conffile prompt
Setting up mongodb-org-tools (6.0.5) ...
Setting up mongodb-org-mongos (6.0.5) ...
Setting up libkrb5-26-heimdal:amd64 (7.7.0+dfsg-1ubuntu1.4) ... dpkg: dependency problems prevent configuration of mongodb-org-database:
 mongodb-org-database depends on mongodb-org-server; however:
  Package mongodb-org-server is not configured yet.

dpkg: error processing package mongodb-org-database (--configure):
 dependency problems - leaving unconfigured
Setting up libheimntlm0-heimdal:amd64 (7.7.0+dfsg-1ubuntu1.4) ... Setting up libgssapi3-heimdal:amd64 (7.7.0+dfsg-1ubuntu1.4) ... dpkg: dependency problems prevent configuration of mongodb-org:
 mongodb-org depends on mongodb-org-database; however:
  Package mongodb-org-database is not configured yet.

dpkg: error processing package mongodb-org (--configure):
 dependency problems - leaving unconfigured
Processing triggers for libc-bin (2.31-0ubuntu9.9) ... Processing triggers for ca-certificates (20211016ubuntu0.20.04.1) ... Updating certificates in /etc/ssl/certs...
0 added, 0 removed; done.
Running hooks in /etc/ca-certificates/update.d...
done.