### PR TITLE
revise README to use a version placeholder in write model tutorial

### DIFF
--- a/custom-write-strategy-example/README.md
+++ b/custom-write-strategy-example/README.md
@@ -16,7 +16,7 @@ want to test your write model strategy with.
 ```kts
 val projectArchiveBaseName = "UpsertAsPartOfDocumentStrategy" // Set the outputted JAR base name
 val mongoKafkaConnectVersion = "<kafka version>" // Set the Kafka connector version to test
-val mongoDriverVersion = "[4.3,4.3.99)"
+val mongoDriverVersion = "4.11.0"
 val kafkaConnectApiVersion = "2.6.0"
 ```
 

--- a/custom-write-strategy-example/README.md
+++ b/custom-write-strategy-example/README.md
@@ -8,11 +8,14 @@ Then copy the `./build/libs/UpsertAsPartOfDocumentStrategy.jar`
 
 ## Customization
 
-The build file (`build.gradle.kts`) has a number of variables that can be changed to help customize the build.
+The build file (`build.gradle.kts`) has a number of variables that can
+be changed to help customize the build. Set the value of the
+`mongoKafkaConnectVersion` variable to the Kafka connector version you
+want to test your write model strategy with.
 
 ```kts
-val projectArchiveBaseName = "UpsertAsPartOfDocumentStrategy" // Set the outputted jar base name
-val mongoKafkaConnectVersion = "1.6.1" // Set the mongo kafka connect version
+val projectArchiveBaseName = "UpsertAsPartOfDocumentStrategy" // Set the outputted JAR base name
+val mongoKafkaConnectVersion = "<kafka version>" // Set the Kafka connector version to test
 val mongoDriverVersion = "[4.3,4.3.99)"
 val kafkaConnectApiVersion = "2.6.0"
 ```

--- a/custom-write-strategy-example/build.gradle.kts
+++ b/custom-write-strategy-example/build.gradle.kts
@@ -16,7 +16,7 @@
 
 val projectArchiveBaseName = "UpsertAsPartOfDocumentStrategy" // Set the outputted JAR base name
 val mongoKafkaConnectVersion = "<kafka version>" // Set the Kafka connector version to test
-val mongoDriverVersion = "[4.3,4.3.99)"
+val mongoDriverVersion = "4.11.0"
 val kafkaConnectApiVersion = "2.6.0"
 
 buildscript {

--- a/custom-write-strategy-example/build.gradle.kts
+++ b/custom-write-strategy-example/build.gradle.kts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-val projectArchiveBaseName = "UpsertAsPartOfDocumentStrategy" // Set the outputted jar base name
-val mongoKafkaConnectVersion = "1.6.1" // Set the mongo kafka connect version
+val projectArchiveBaseName = "UpsertAsPartOfDocumentStrategy" // Set the outputted JAR base name
+val mongoKafkaConnectVersion = "<kafka version>" // Set the Kafka connector version to test
 val mongoDriverVersion = "[4.3,4.3.99)"
 val kafkaConnectApiVersion = "2.6.0"
 


### PR DESCRIPTION
I noticed that the custom write model strategy tutorial used an outdated Kafka connector version, and I clarified that users should instead select a version to test.